### PR TITLE
Bastion: Debian 13 + XFCE, xrdp, LightDM after success

### DIFF
--- a/00_vars_lab_track.tf
+++ b/00_vars_lab_track.tf
@@ -13,7 +13,7 @@
 
 variable "lab_track" {
   type        = string
-  default     = "operations"
+  default     = "s3"
   description = "Curriculum profile; selects one block from local.lab_track_profiles."
 
   validation {
@@ -78,8 +78,8 @@ variable "external_network-name" {
 
 variable "bastion-image" {
   type        = string
-  default     = "Ubuntu-20.04"
-  description = "Bastion image name in Glance."
+  default     = "Debian-12"
+  description = "Bastion image name in Glance (Debian 12 cloud image recommended, e.g. genericcloud; name must match your catalog)."
 }
 
 variable "bastion-flavor" {
@@ -98,7 +98,7 @@ variable "bastion-storage_policy" {
 
 variable "ssh_key" {
   type        = string
-  default     = "~/.ssh/id_rsa.pub"
+  default     = "~/.ssh/akochkov.pub"
   description = "Path to your public SSH key for bastion and cluster nodes."
 }
 

--- a/00_vars_lab_track.tf
+++ b/00_vars_lab_track.tf
@@ -13,7 +13,7 @@
 
 variable "lab_track" {
   type        = string
-  default     = "s3"
+  default     = "operations"
   description = "Curriculum profile; selects one block from local.lab_track_profiles."
 
   validation {
@@ -78,8 +78,8 @@ variable "external_network-name" {
 
 variable "bastion-image" {
   type        = string
-  default     = "Debian-12"
-  description = "Bastion image name in Glance (Debian 12 cloud image recommended, e.g. genericcloud; name must match your catalog)."
+  default     = "Debian-13"
+  description = "Bastion image name in Glance (Debian 13 / trixie generic cloud image recommended; name must match your catalog)."
 }
 
 variable "bastion-flavor" {

--- a/00_vars_lab_track.tf
+++ b/00_vars_lab_track.tf
@@ -79,7 +79,7 @@ variable "external_network-name" {
 variable "bastion-image" {
   type        = string
   default     = "Debian-13"
-  description = "Bastion image name in Glance (Debian 13 / trixie generic cloud image recommended; name must match your catalog)."
+  description = "Bastion image name in Glance (Debian 13 / trixie generic cloud image required; name must match your catalog)."
 }
 
 variable "bastion-flavor" {
@@ -98,7 +98,7 @@ variable "bastion-storage_policy" {
 
 variable "ssh_key" {
   type        = string
-  default     = "~/.ssh/akochkov.pub"
+  default     = "~/.ssh/id_rsa.pub"
   description = "Path to your public SSH key for bastion and cluster nodes."
 }
 

--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ If Bastion VM is still being configured, you will see the following prompt:
 
 Once the configuration of Bastion is complete, you should see the **LightDM** graphical login prompt on the cloud **VGA / web console** (serial-only consoles do not show the GUI). Log in as **`student`** with the Terraform-generated password.
 
+If the console **shows the login screen but keyboard or mouse do not respond**, the usual causes are missing **Xorg input drivers** (addressed by installing **`xserver-xorg-input-all`**) or a **SPICE** web console without **`spice-vdagent`** / **`qemu-guest-agent`** running in the guest. This stack installs and enables those; after redeploy, if it still fails, check **`/var/log/Xorg.0.log`**, **`journalctl -u lightdm`**, and **`systemctl status spice-vdagentd qemu-guest-agent`**.
+
 <img alt="Ready state" src="readme/bastion_ready.png" title="Bastion VM is ready" width="500"/>
 
 ### Verify that the nested Virtuozzo Infrastructure cluster is fully configured.

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ If Bastion VM is still being configured, you will see the following prompt:
 
 <img alt="&quot;Customization in progress&quot; Prompt" src="readme/bastion_not_ready.png" title="Bastion VM is not ready" width="500"/>
 
-Once the configuration of Bastion is complete, you should see the graphical login prompt:
+Once the configuration of Bastion is complete, you should see the **LightDM** graphical login prompt on the cloud **VGA / web console** (serial-only consoles do not show the GUI). Log in as **`student`** with the Terraform-generated password.
 
 <img alt="Ready state" src="readme/bastion_ready.png" title="Bastion VM is ready" width="500"/>
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ _If the diagram shows more cluster nodes, treat extras as **operations** context
 
 The repository contains:
 - Terraform plan files, ending with `.tf` extension.
-- Cloud-init scripts under [`cloud-init/`](cloud-init/): [`node.sh`](cloud-init/node.sh) and [`bastion.sh`](cloud-init/bastion.sh), with behavior gated by **`lab_track`** (Terraform also prepends [`_lab_log.sh`](cloud-init/_lab_log.sh) for shared logging).
+- Cloud-init scripts under [`cloud-init/`](cloud-init/): [`node.sh`](cloud-init/node.sh) (Virtuozzo cluster nodes) and [`bastion.sh`](cloud-init/bastion.sh) (**Debian 12** bastion: XFCE, xrdp, TigerVNC), with bastion behavior gated by **`lab_track`** (Terraform also prepends [`_lab_log.sh`](cloud-init/_lab_log.sh) for shared logging).
 - `openstack-creds.sh` for sourcing cloud credentials.
 - Auxiliary files for students, including `WonderSI_Logos.zip`.
 
@@ -102,10 +102,10 @@ The project you are working with must have the following images:
   - https://repo.virtuozzo.com/vz-platform/releases/7.0/x86_64/iso/vz-platform-7.0.iso
 - Virtuozzo Infrastructure QCOW2 image
   - https://downloads.virtuozzo.com/vzlinux-iso-hci-7.0.0-251.qcow2
-- Ubuntu 20.04 QCOW2 image (for the **bastion** VM)
-  - https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64.img
+- Debian 12 **generic cloud** image for the **bastion** VM (Glance name must match **`bastion-image`**, default `Debian-12`)
+  - Official builds: [Debian cloud images — bookworm](https://cloud.debian.org/images/cloud/bookworm/) (e.g. `debian-12-generic-amd64`). Enable **`contrib`**, **`non-free`**, and **`non-free-firmware`** in apt if your NIC needs non-free firmware; [`cloud-init/bastion.sh`](cloud-init/bastion.sh) attempts to extend `debian.sources` / `sources.list` when `non-free-firmware` is missing.
 
-Please do not use other versions of Virtuozzo Infrastructure or Ubuntu images, as the deployment script will likely fail to configure them.
+Please do not use other versions of Virtuozzo Infrastructure images than those intended for this lab, as the deployment script will likely fail to configure them. The **bastion** image must be **Debian 12**-based (cloud-init assumes `apt` and package names from Bookworm); adjust **`bastion-image`** to the exact name in your Glance catalog.
 
 ## Sandbox provisioning
 
@@ -240,13 +240,13 @@ Adjust bastion variables in [`00_vars_lab_track.tf`](00_vars_lab_track.tf):
 ##### Bastion image name
 
 You need to set the `bastion-image` variable to the name of the Bastion image in your project.
-For example, if in your cloud Bastion image is named `Ubuntu-20.04`, the variable should look like this:
+For example, if in your cloud the image is named `Debian-12`, the variable should look like this:
 
 ```
 ## Bastion image
 variable "bastion-image" {
   type = string
-  default = "Ubuntu-20.04" # If required, replace the image name with the one you have in the cloud
+  default = "Debian-12" # If required, replace the image name with the one you have in the cloud
 }
 ```
 
@@ -339,9 +339,11 @@ After `terraform apply` completes, the connection details are displayed in the o
 
 ```
 bastion_connection_info = {
-  "password"    = "xK#9mPq!2wLnR$vT"
-  "rdp_address" = "203.0.113.45:3390"
-  "username"    = "student"
+  "password"     = "xK#9mPq!2wLnR$vT"
+  "rdp_address"  = "203.0.113.45:3390"
+  "ssh_address"  = "203.0.113.45:2228"
+  "username"     = "student"
+  "vnc_address"  = "203.0.113.45:5901"
 }
 ```
 
@@ -361,7 +363,11 @@ terraform output -json bastion_connection_info
 ```
 terraform output -json bastion_connection_info | jq -r '.password'
 terraform output -json bastion_connection_info | jq -r '.rdp_address'
+terraform output -json bastion_connection_info | jq -r '.vnc_address'
+terraform output -json bastion_connection_info | jq -r '.ssh_address'
 ```
+
+Ensure your project **Neutron security group** (or equivalent) allows inbound **TCP 3390** (RDP), **TCP 5901** (TigerVNC on display `:1`), and **TCP 2228** (SSH to the `student` user) to the bastion floating IP if students connect from outside a locked-down network.
 
 ## Verifying results
 
@@ -380,11 +386,11 @@ Once the configuration of Bastion is complete, you should see the graphical logi
 
 ### Verify that the nested Virtuozzo Infrastructure cluster is fully configured.
 
-Students typically use an **RDP** connection to the Bastion VM.
+Students typically use an **RDP** connection to the Bastion VM (XFCE desktop). **TigerVNC** on port **5901** is also enabled for the same session stack; **SSH** for the `student` user listens on port **2228** (see `ssh_address` in Terraform output). Use a **Python venv** for installing the OpenStack client (`python3 -m venv …`) because Debian enables *externally managed* protection for system-wide `pip`.
 
 To verify that the nested Virtuozzo Infrastructure cluster is ready, do the following:
 
-1. Connect to the Bastion VM using the RDP client. Use the address and credentials from `terraform output bastion_connection_info`.
+1. Connect to the Bastion VM using an RDP client. Use **`rdp_address`**, **`username`**, and **`password`** from `terraform output bastion_connection_info`. Optionally test **VNC** with **`vnc_address`** and the same password.
 2. Access nested Virtuozzo Infrastructure Admin Panel using the desktop shortcut and log in as **`admin`**:
 
 <img alt="Bastion VM desktop shortcut" src="readme/bastion_desktop.png" title="Connecting to Virtuozzo Infrastructure Admin Panel" width="500"/>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ _If the diagram shows more cluster nodes, treat extras as **operations** context
 
 The repository contains:
 - Terraform plan files, ending with `.tf` extension.
-- Cloud-init scripts under [`cloud-init/`](cloud-init/): [`node.sh`](cloud-init/node.sh) (Virtuozzo cluster nodes) and [`bastion.sh`](cloud-init/bastion.sh) (**Debian 12** bastion: XFCE, xrdp, TigerVNC), with bastion behavior gated by **`lab_track`** (Terraform also prepends [`_lab_log.sh`](cloud-init/_lab_log.sh) for shared logging).
+- Cloud-init scripts under [`cloud-init/`](cloud-init/): [`node.sh`](cloud-init/node.sh) (Virtuozzo cluster nodes) and [`bastion.sh`](cloud-init/bastion.sh) (**Debian 12** bastion: XFCE, xrdp), with bastion behavior gated by **`lab_track`** (Terraform also prepends [`_lab_log.sh`](cloud-init/_lab_log.sh) for shared logging).
 - `openstack-creds.sh` for sourcing cloud credentials.
 - Auxiliary files for students, including `WonderSI_Logos.zip`.
 
@@ -343,7 +343,6 @@ bastion_connection_info = {
   "rdp_address"  = "203.0.113.45:3390"
   "ssh_address"  = "203.0.113.45:2228"
   "username"     = "student"
-  "vnc_address"  = "203.0.113.45:5901"
 }
 ```
 
@@ -363,11 +362,10 @@ terraform output -json bastion_connection_info
 ```
 terraform output -json bastion_connection_info | jq -r '.password'
 terraform output -json bastion_connection_info | jq -r '.rdp_address'
-terraform output -json bastion_connection_info | jq -r '.vnc_address'
 terraform output -json bastion_connection_info | jq -r '.ssh_address'
 ```
 
-Ensure your project **Neutron security group** (or equivalent) allows inbound **TCP 3390** (RDP), **TCP 5901** (TigerVNC on display `:1`), and **TCP 2228** (SSH to the `student` user) to the bastion floating IP if students connect from outside a locked-down network.
+Ensure your project **Neutron security group** (or equivalent) allows inbound **TCP 3390** (RDP) and **TCP 2228** (SSH to the `student` user) to the bastion floating IP if students connect from outside a locked-down network.
 
 ## Verifying results
 
@@ -388,11 +386,11 @@ If the console **shows the login screen but keyboard or mouse do not respond**, 
 
 ### Verify that the nested Virtuozzo Infrastructure cluster is fully configured.
 
-Students typically use an **RDP** connection to the Bastion VM (XFCE desktop). **TigerVNC** on port **5901** is also enabled for the same session stack; **SSH** for the `student` user listens on port **2228** (see `ssh_address` in Terraform output). Use a **Python venv** for installing the OpenStack client (`python3 -m venv …`) because Debian enables *externally managed* protection for system-wide `pip`.
+Students typically use an **RDP** connection to the Bastion VM (XFCE desktop). **SSH** for the `student` user listens on port **2228** (see `ssh_address` in Terraform output). Use a **Python venv** for installing the OpenStack client (`python3 -m venv …`) because Debian enables *externally managed* protection for system-wide `pip`.
 
 To verify that the nested Virtuozzo Infrastructure cluster is ready, do the following:
 
-1. Connect to the Bastion VM using an RDP client. Use **`rdp_address`**, **`username`**, and **`password`** from `terraform output bastion_connection_info`. Optionally test **VNC** with **`vnc_address`** and the same password.
+1. Connect to the Bastion VM using an RDP client. Use **`rdp_address`**, **`username`**, and **`password`** from `terraform output bastion_connection_info`.
 2. Access nested Virtuozzo Infrastructure Admin Panel using the desktop shortcut and log in as **`admin`**:
 
 <img alt="Bastion VM desktop shortcut" src="readme/bastion_desktop.png" title="Connecting to Virtuozzo Infrastructure Admin Panel" width="500"/>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ _If the diagram shows more cluster nodes, treat extras as **operations** context
 
 The repository contains:
 - Terraform plan files, ending with `.tf` extension.
-- Cloud-init scripts under [`cloud-init/`](cloud-init/): [`node.sh`](cloud-init/node.sh) (Virtuozzo cluster nodes) and [`bastion.sh`](cloud-init/bastion.sh) (**Debian 12** bastion: XFCE, xrdp), with bastion behavior gated by **`lab_track`** (Terraform also prepends [`_lab_log.sh`](cloud-init/_lab_log.sh) for shared logging).
+- Cloud-init scripts under [`cloud-init/`](cloud-init/): [`node.sh`](cloud-init/node.sh) (Virtuozzo cluster nodes) and [`bastion.sh`](cloud-init/bastion.sh) (**Debian 13** bastion: XFCE, xrdp), with bastion behavior gated by **`lab_track`** (Terraform also prepends [`_lab_log.sh`](cloud-init/_lab_log.sh) for shared logging).
 - `openstack-creds.sh` for sourcing cloud credentials.
 - Auxiliary files for students, including `WonderSI_Logos.zip`.
 
@@ -102,10 +102,10 @@ The project you are working with must have the following images:
   - https://repo.virtuozzo.com/vz-platform/releases/7.0/x86_64/iso/vz-platform-7.0.iso
 - Virtuozzo Infrastructure QCOW2 image
   - https://downloads.virtuozzo.com/vzlinux-iso-hci-7.0.0-251.qcow2
-- Debian 12 **generic cloud** image for the **bastion** VM (Glance name must match **`bastion-image`**, default `Debian-12`)
-  - Official builds: [Debian cloud images — bookworm](https://cloud.debian.org/images/cloud/bookworm/) (e.g. `debian-12-generic-amd64`). Enable **`contrib`**, **`non-free`**, and **`non-free-firmware`** in apt if your NIC needs non-free firmware; [`cloud-init/bastion.sh`](cloud-init/bastion.sh) attempts to extend `debian.sources` / `sources.list` when `non-free-firmware` is missing.
+- Debian 13 **generic cloud** image for the **bastion** VM (Glance name must match **`bastion-image`**, default `Debian-13`)
+  - Official builds: [Debian cloud images — trixie](https://cloud.debian.org/images/cloud/trixie/) (e.g. `debian-13-generic-amd64`). Enable **`contrib`**, **`non-free`**, and **`non-free-firmware`** in apt if your NIC needs non-free firmware; [`cloud-init/bastion.sh`](cloud-init/bastion.sh) attempts to extend `debian.sources` / `sources.list` when `non-free-firmware` is missing.
 
-Please do not use other versions of Virtuozzo Infrastructure images than those intended for this lab, as the deployment script will likely fail to configure them. The **bastion** image must be **Debian 12**-based (cloud-init assumes `apt` and package names from Bookworm); adjust **`bastion-image`** to the exact name in your Glance catalog.
+Please do not use other versions of Virtuozzo Infrastructure images than those intended for this lab, as the deployment script will likely fail to configure them. The **bastion** image must be **Debian 13**-based (cloud-init assumes `apt` and package names from **trixie**); adjust **`bastion-image`** to the exact name in your Glance catalog.
 
 ## Sandbox provisioning
 
@@ -240,13 +240,13 @@ Adjust bastion variables in [`00_vars_lab_track.tf`](00_vars_lab_track.tf):
 ##### Bastion image name
 
 You need to set the `bastion-image` variable to the name of the Bastion image in your project.
-For example, if in your cloud the image is named `Debian-12`, the variable should look like this:
+For example, if in your cloud the image is named `Debian-13`, the variable should look like this:
 
 ```
 ## Bastion image
 variable "bastion-image" {
   type = string
-  default = "Debian-12" # If required, replace the image name with the one you have in the cloud
+  default = "Debian-13" # If required, replace the image name with the one you have in the cloud
 }
 ```
 

--- a/cloud-init/bastion.sh
+++ b/cloud-init/bastion.sh
@@ -105,20 +105,31 @@ SSHEOF
 }
 
 bastion_desktop_shortcuts() {
-  lab_log INFO "Creating desktop shortcuts"
+  lab_log INFO "Creating desktop shortcuts (Application launchers — avoids untrusted Type=Link prompts)"
   mkdir -p /home/student/Desktop
-  echo "[Desktop Entry]
-Encoding=UTF-8
+  cat >"/home/student/Desktop/VHI Admin Panel.desktop" <<'DESK1'
+[Desktop Entry]
+Version=1.0
+Type=Application
 Name=VHI Admin Panel
-Type=Link
-URL=https://cloud.student.lab:8888
-Icon=text-html" > "/home/student/Desktop/VHI Admin Panel.desktop"
-  echo "[Desktop Entry]
-Encoding=UTF-8
+Comment=Open VHI Admin Panel in Firefox
+Exec=/usr/bin/firefox-esr https://cloud.student.lab:8888
+Icon=firefox-esr
+Terminal=false
+StartupNotify=true
+DESK1
+  cat >"/home/student/Desktop/VHI Self-Service Panel.desktop" <<'DESK2'
+[Desktop Entry]
+Version=1.0
+Type=Application
 Name=VHI Self-Service Panel
-Type=Link
-URL=https://cloud.student.lab:8800
-Icon=text-html" > "/home/student/Desktop/VHI Self-Service Panel.desktop"
+Comment=Open VHI Self-Service in Firefox
+Exec=/usr/bin/firefox-esr https://cloud.student.lab:8800
+Icon=firefox-esr
+Terminal=false
+StartupNotify=true
+DESK2
+  chmod 755 /home/student/Desktop/*.desktop
   chown -R student:student /home/student/Desktop
 }
 
@@ -137,18 +148,23 @@ bastion_update_hosts() {
 
 bastion_install_desktop_packages() {
   run_apt "apt-get update -eany -q" "apt metadata refresh (desktop stack)"
+  lab_log INFO "Selecting lightdm as display manager (local / VGA console graphical login)"
+  echo 'lightdm shared/default-x-display-manager select lightdm' | debconf-set-selections
+
   run_apt "apt-get install -y -q --no-install-recommends \
     xfce4 \
+    xfce4-terminal \
     dbus-x11 \
+    lightdm lightdm-gtk-greeter \
     xrdp xorgxrdp \
     tigervnc-standalone-server tigervnc-common \
     firefox-esr \
     python3 python3-pip python3-venv \
-    firmware-linux" "XFCE, RDP, TigerVNC, Firefox, Python, firmware"
+    firmware-linux" "XFCE, LightDM, RDP, TigerVNC, Firefox, Python, firmware"
 }
 
 bastion_xfce_performance_defaults() {
-  lab_log INFO "Disabling XFCE compositing for lighter remote sessions"
+  lab_log INFO "Disabling XFCE compositing; default terminal = xfce4-terminal"
   install -d -m 755 -o student -g student /home/student/.config/xfce4/xfconf/xfce-perchannel-xml
   cat > /home/student/.config/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml <<'XFM'
 <?xml version="1.0" encoding="UTF-8"?>
@@ -160,7 +176,31 @@ bastion_xfce_performance_defaults() {
   </property>
 </channel>
 XFM
+  cat > /home/student/.config/xfce4/xfconf/xfce-perchannel-xml/helpers.xml <<'HLP'
+<?xml version="1.0" encoding="UTF-8"?>
+<channel name="helpers" version="1.0">
+  <property name="TerminalEmulator" type="string" value="/usr/bin/xfce4-terminal"/>
+</channel>
+HLP
   chown -R student:student /home/student/.config
+
+  if command -v update-alternatives >/dev/null 2>&1; then
+    update-alternatives --set x-terminal-emulator /usr/bin/xfce4-terminal 2>/dev/null || true
+  fi
+}
+
+bastion_console_graphical_target() {
+  lab_log INFO "Enabling graphical target and LightDM for local console (VGA / web console)"
+  install -d /etc/lightdm/lightdm.conf.d
+  cat >/etc/lightdm/lightdm.conf.d/01-console-vt.conf <<'LDC'
+[LightDM]
+# Prefer the first virtual terminal so typical cloud HTML5 consoles show the greeter.
+minimum-vt=1
+LDC
+  systemctl set-default graphical.target
+  systemctl enable lightdm.service
+  systemctl daemon-reload
+  systemctl start lightdm.service || lab_log ERROR "lightdm failed to start (see journalctl -u lightdm)"
 }
 
 bastion_xrdp_configure() {
@@ -257,11 +297,12 @@ bastion_banner_and_motd
 bastion_apt_enable_firmware_components
 bastion_bootstrap_base_packages
 bastion_student_and_ssh
-bastion_desktop_shortcuts
 track_is_s3 && bastion_s3_extras
 bastion_update_hosts
 bastion_install_desktop_packages
 bastion_xfce_performance_defaults
+bastion_desktop_shortcuts
+bastion_console_graphical_target
 bastion_xrdp_configure
 bastion_tigervnc_setup
 bastion_upgrade

--- a/cloud-init/bastion.sh
+++ b/cloud-init/bastion.sh
@@ -1,5 +1,6 @@
 # Unified bastion customization; lab_log from prepended _lab_log.sh.
 # Template vars: student_password, lab_track
+# Target: Debian stable + XFCE + xrdp (xorgxrdp) + optional TigerVNC.
 
 LAB_TRACK="${lab_track}"
 
@@ -53,10 +54,50 @@ bastion_banner_and_motd() {
   systemctl restart getty@tty1.service
 }
 
+bastion_apt_enable_firmware_components() {
+  lab_log INFO "Ensuring apt sources include contrib, non-free, and non-free-firmware where needed"
+  if grep -Rqs 'non-free-firmware' /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null; then
+    lab_log INFO "non-free-firmware already referenced in apt sources"
+    return 0
+  fi
+  if [ -f /etc/apt/sources.list.d/debian.sources ]; then
+    sed -i \
+      -e 's/^Components: main$/Components: main contrib non-free non-free-firmware/' \
+      -e 's/^Components: main contrib$/Components: main contrib non-free non-free-firmware/' \
+      -e 's/^Components: main contrib non-free$/Components: main contrib non-free non-free-firmware/' \
+      /etc/apt/sources.list.d/debian.sources 2>/dev/null || true
+  fi
+  if grep -q '^deb ' /etc/apt/sources.list 2>/dev/null; then
+    sed -i 's/ main$/ main contrib non-free non-free-firmware/' /etc/apt/sources.list
+  fi
+}
+
+bastion_bootstrap_base_packages() {
+  run_apt "apt-get update -eany -q" "apt metadata refresh (bootstrap)"
+  run_apt "apt-get install -y -q sudo ca-certificates" "sudo and CA certs before creating student user"
+}
+
 bastion_student_and_ssh() {
   lab_log INFO "Setting up 'student' user"
   useradd -m -s /bin/bash -G sudo student
   echo "student:${student_password}" | chpasswd
+
+  for u in debian ubuntu; do
+    if [ -f "/home/$u/.ssh/authorized_keys" ]; then
+      lab_log INFO "Copying SSH authorized_keys from $u to student"
+      install -d -m 700 -o student -g student /home/student/.ssh
+      cp "/home/$u/.ssh/authorized_keys" /home/student/.ssh/authorized_keys
+      chmod 600 /home/student/.ssh/authorized_keys
+      chown -R student:student /home/student/.ssh
+      break
+    fi
+  done
+
+  lab_log INFO "Allowing password authentication for user student (OpenStack client over SSH)"
+  cat >/etc/ssh/sshd_config.d/90-student-auth.conf <<'SSHEOF'
+Match User student
+    PasswordAuthentication yes
+SSHEOF
 
   lab_log INFO "Reconfiguring the SSH port to 2228"
   sed -i 's/#Port 22/Port 2228/g' /etc/ssh/sshd_config
@@ -95,21 +136,97 @@ bastion_update_hosts() {
 }
 
 bastion_install_desktop_packages() {
-  run_apt "apt-get update -eany -q" "system update"
-  run_apt "apt-get install -y -q cinnamon-desktop-environment cinnamon-core xrdp python3-pip" "desktop environment installation"
+  run_apt "apt-get update -eany -q" "apt metadata refresh (desktop stack)"
+  run_apt "apt-get install -y -q --no-install-recommends \
+    xfce4 \
+    dbus-x11 \
+    xrdp xorgxrdp \
+    tigervnc-standalone-server tigervnc-common \
+    firefox-esr \
+    python3 python3-pip python3-venv \
+    firmware-linux" "XFCE, RDP, TigerVNC, Firefox, Python, firmware"
 }
 
-bastion_xrdp_cinnamon() {
-  lab_log INFO "Configuring XRDP"
-  echo "cinnamon-session" > /home/student/.xsession
-  sed -i 's/3389/3390/g' /etc/xrdp/xrdp.ini
-  systemctl restart xrdp.service
+bastion_xfce_performance_defaults() {
+  lab_log INFO "Disabling XFCE compositing for lighter remote sessions"
+  install -d -m 755 -o student -g student /home/student/.config/xfce4/xfconf/xfce-perchannel-xml
+  cat > /home/student/.config/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml <<'XFM'
+<?xml version="1.0" encoding="UTF-8"?>
+<channel name="xfwm4" version="1.0">
+  <property name="general" type="empty">
+    <property name="use_compositing" type="bool" value="false"/>
+    <property name="show_dock_shadow" type="bool" value="false"/>
+    <property name="show_frame_shadow" type="bool" value="false"/>
+  </property>
+</channel>
+XFM
+  chown -R student:student /home/student/.config
+}
 
-  lab_log INFO "Configuring Cinnamon for RDP"
-  mkdir -p /home/student/.config/gtk-3.0/
-  echo "[Settings]" > /home/student/.config/gtk-3.0/settings.ini
-  echo "gtk-modules=\"appmenu-gtk-module,cinnamon-applet-proxy\"" >> /home/student/.config/gtk-3.0/settings.ini
-  chown -R student:student /home/student
+bastion_xrdp_configure() {
+  lab_log INFO "Configuring XRDP for XFCE (xorgxrdp)"
+  cat > /home/student/.xsession <<'XS'
+#!/bin/sh
+exec startxfce4
+XS
+  chmod 755 /home/student/.xsession
+  chown student:student /home/student/.xsession
+
+  sed -i 's/^port=3389/port=3390/' /etc/xrdp/xrdp.ini
+  sed -i 's/^#*port=3389/port=3390/' /etc/xrdp/xrdp.ini
+
+  if grep -q '^tcp_nodelay=' /etc/xrdp/xrdp.ini; then
+    sed -i 's/^tcp_nodelay=.*/tcp_nodelay=true/' /etc/xrdp/xrdp.ini
+  elif grep -q '^\[Globals\]' /etc/xrdp/xrdp.ini; then
+    sed -i '/^\[Globals\]/a tcp_nodelay=true' /etc/xrdp/xrdp.ini
+  fi
+  if grep -q '^max_bpp=' /etc/xrdp/xrdp.ini; then
+    sed -i 's/^max_bpp=.*/max_bpp=24/' /etc/xrdp/xrdp.ini
+  fi
+
+  systemctl enable xrdp
+  systemctl restart xrdp.service
+}
+
+bastion_tigervnc_setup() {
+  lab_log INFO "Configuring TigerVNC (display :1, TCP 5901) for student"
+  install -d -m 700 -o student -g student /home/student/.vnc
+  cat > /home/student/.vnc/xstartup <<'XVNC'
+#!/bin/sh
+unset SESSION_MANAGER
+unset DBUS_SESSION_BUS_ADDRESS
+exec /usr/bin/startxfce4
+XVNC
+  chmod 755 /home/student/.vnc/xstartup
+  chown -R student:student /home/student/.vnc
+
+  printf '%s\n' "${student_password}" | sudo -u student env HOME=/home/student vncpasswd -f >/home/student/.vnc/passwd
+  chmod 600 /home/student/.vnc/passwd
+  chown student:student /home/student/.vnc/passwd
+
+  cat > /etc/systemd/system/tigervnc-student.service <<'UNIT'
+[Unit]
+Description=TigerVNC XFCE session for student (display :1, port 5901)
+After=network.target
+
+[Service]
+Type=simple
+User=student
+Group=student
+Environment=HOME=/home/student
+WorkingDirectory=/home/student
+ExecStart=/usr/bin/tigervncserver :1 -fg -geometry 1920x1080 -depth 24 -localhost no -SecurityTypes VncAuth
+ExecStop=/usr/bin/tigervncserver -kill :1
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+  systemctl daemon-reload
+  systemctl enable tigervnc-student.service
+  systemctl start tigervnc-student.service || lab_log ERROR "TigerVNC service start failed (check /var/log/tigervnc or journalctl)"
 }
 
 bastion_upgrade() {
@@ -137,11 +254,15 @@ bastion_finalize_or_fail() {
 # Main: order of operations — customization steps run top to bottom.
 # -----------------------------------------------------------------------------
 bastion_banner_and_motd
+bastion_apt_enable_firmware_components
+bastion_bootstrap_base_packages
 bastion_student_and_ssh
 bastion_desktop_shortcuts
 track_is_s3 && bastion_s3_extras
 bastion_update_hosts
 bastion_install_desktop_packages
-bastion_xrdp_cinnamon
+bastion_xfce_performance_defaults
+bastion_xrdp_configure
+bastion_tigervnc_setup
 bastion_upgrade
 bastion_finalize_or_fail

--- a/cloud-init/bastion.sh
+++ b/cloud-init/bastion.sh
@@ -1,6 +1,6 @@
 # Unified bastion customization; lab_log from prepended _lab_log.sh.
 # Template vars: student_password, lab_track
-# Target: Debian stable + XFCE + xrdp (xorgxrdp) + optional TigerVNC.
+# Target: Debian stable + XFCE + xrdp (xorgxrdp).
 
 LAB_TRACK="${lab_track}"
 
@@ -160,11 +160,10 @@ bastion_install_desktop_packages() {
     spice-vdagent \
     qemu-guest-agent \
     xrdp xorgxrdp \
-    tigervnc-standalone-server tigervnc-common \
     firefox-esr \
     python3 python3-pip python3-venv pipx \
     locales-all \
-    firmware-linux" "XFCE, LightDM, Xorg input drivers, SPICE/QEMU agents, RDP, TigerVNC, Firefox, Python, locales, firmware"
+    firmware-linux" "XFCE, LightDM, Xorg input drivers, SPICE/QEMU agents, RDP, Firefox, Python, locales, firmware"
 }
 
 bastion_locales_and_ssh_client_quirks() {
@@ -252,47 +251,6 @@ XS
   systemctl restart xrdp.service
 }
 
-bastion_tigervnc_setup() {
-  lab_log INFO "Configuring TigerVNC (display :1, TCP 5901) for student"
-  install -d -m 700 -o student -g student /home/student/.vnc
-  cat > /home/student/.vnc/xstartup <<'XVNC'
-#!/bin/sh
-unset SESSION_MANAGER
-unset DBUS_SESSION_BUS_ADDRESS
-exec /usr/bin/startxfce4
-XVNC
-  chmod 755 /home/student/.vnc/xstartup
-  chown -R student:student /home/student/.vnc
-
-  printf '%s\n' "${student_password}" | sudo -u student env HOME=/home/student vncpasswd -f >/home/student/.vnc/passwd
-  chmod 600 /home/student/.vnc/passwd
-  chown student:student /home/student/.vnc/passwd
-
-  cat > /etc/systemd/system/tigervnc-student.service <<'UNIT'
-[Unit]
-Description=TigerVNC XFCE session for student (display :1, port 5901)
-After=network.target
-
-[Service]
-Type=simple
-User=student
-Group=student
-Environment=HOME=/home/student
-WorkingDirectory=/home/student
-ExecStart=/usr/bin/tigervncserver :1 -fg -geometry 1920x1080 -depth 24 -localhost no -SecurityTypes VncAuth
-ExecStop=/usr/bin/tigervncserver -kill :1
-Restart=on-failure
-RestartSec=5
-
-[Install]
-WantedBy=multi-user.target
-UNIT
-
-  systemctl daemon-reload
-  systemctl enable tigervnc-student.service
-  systemctl start tigervnc-student.service || lab_log ERROR "TigerVNC service start failed (check /var/log/tigervnc or journalctl)"
-}
-
 bastion_upgrade() {
   run_apt "apt-get upgrade -y -q" "system upgrade"
 }
@@ -329,6 +287,5 @@ bastion_xfce_performance_defaults
 bastion_desktop_shortcuts
 bastion_console_graphical_target
 bastion_xrdp_configure
-bastion_tigervnc_setup
 bastion_upgrade
 bastion_finalize_or_fail

--- a/cloud-init/bastion.sh
+++ b/cloud-init/bastion.sh
@@ -203,7 +203,7 @@ HLP
 }
 
 bastion_console_graphical_target() {
-  lab_log INFO "Enabling graphical target and LightDM for local console (VGA / web console)"
+  lab_log INFO "Enabling local console GUI (LightDM) after successful customization"
   install -d /etc/lightdm/lightdm.conf.d
   cat >/etc/lightdm/lightdm.conf.d/01-console-vt.conf <<'LDC'
 [LightDM]
@@ -264,6 +264,7 @@ bastion_finalize_or_fail() {
     lab_log INFO "Customization finished successfully"
     rm /etc/motd
     mv /etc/issue{.bak,}
+    bastion_console_graphical_target
     reboot
   fi
 }
@@ -282,7 +283,6 @@ bastion_install_desktop_packages
 bastion_locales_and_ssh_client_quirks
 bastion_xfce_performance_defaults
 bastion_desktop_shortcuts
-bastion_console_graphical_target
 bastion_xrdp_configure
 bastion_upgrade
 bastion_finalize_or_fail

--- a/cloud-init/bastion.sh
+++ b/cloud-init/bastion.sh
@@ -174,8 +174,8 @@ LANG=C.UTF-8
 LOC
   cat >/etc/profile.d/00-fix-ssh-locale.sh <<'FIX'
 # Run before cloud-init locale-check: macOS often forwards LC_CTYPE=UTF-8.
-case ${LC_ALL-} in (UTF-8|utf-8) export LC_ALL=C.UTF-8 ;; esac
-case ${LC_CTYPE-} in (UTF-8|utf-8) export LC_CTYPE=C.UTF-8 ;; esac
+case "$LC_ALL" in (UTF-8|utf-8) export LC_ALL=C.UTF-8 ;; esac
+case "$LC_CTYPE" in (UTF-8|utf-8) export LC_CTYPE=C.UTF-8 ;; esac
 FIX
   chmod 644 /etc/profile.d/00-fix-ssh-locale.sh
 }

--- a/cloud-init/bastion.sh
+++ b/cloud-init/bastion.sh
@@ -156,11 +156,14 @@ bastion_install_desktop_packages() {
     xfce4-terminal \
     dbus-x11 \
     lightdm lightdm-gtk-greeter \
+    xserver-xorg-core xserver-xorg-input-all \
+    spice-vdagent \
+    qemu-guest-agent \
     xrdp xorgxrdp \
     tigervnc-standalone-server tigervnc-common \
     firefox-esr \
     python3 python3-pip python3-venv \
-    firmware-linux" "XFCE, LightDM, RDP, TigerVNC, Firefox, Python, firmware"
+    firmware-linux" "XFCE, LightDM, Xorg input drivers, SPICE/QEMU agents, RDP, TigerVNC, Firefox, Python, firmware"
 }
 
 bastion_xfce_performance_defaults() {
@@ -197,9 +200,16 @@ bastion_console_graphical_target() {
 # Prefer the first virtual terminal so typical cloud HTML5 consoles show the greeter.
 minimum-vt=1
 LDC
+  systemctl daemon-reload
+
+  lab_log INFO "Guest agents for cloud web console keyboard/mouse (SPICE / QEMU)"
+  systemctl enable qemu-guest-agent.service 2>/dev/null || true
+  systemctl start qemu-guest-agent.service 2>/dev/null || true
+  systemctl enable spice-vdagentd.service 2>/dev/null || true
+  systemctl start spice-vdagentd.service 2>/dev/null || true
+
   systemctl set-default graphical.target
   systemctl enable lightdm.service
-  systemctl daemon-reload
   systemctl start lightdm.service || lab_log ERROR "lightdm failed to start (see journalctl -u lightdm)"
 }
 

--- a/cloud-init/bastion.sh
+++ b/cloud-init/bastion.sh
@@ -162,8 +162,22 @@ bastion_install_desktop_packages() {
     xrdp xorgxrdp \
     tigervnc-standalone-server tigervnc-common \
     firefox-esr \
-    python3 python3-pip python3-venv \
-    firmware-linux" "XFCE, LightDM, Xorg input drivers, SPICE/QEMU agents, RDP, TigerVNC, Firefox, Python, firmware"
+    python3 python3-pip python3-venv pipx \
+    locales-all \
+    firmware-linux" "XFCE, LightDM, Xorg input drivers, SPICE/QEMU agents, RDP, TigerVNC, Firefox, Python, locales, firmware"
+}
+
+bastion_locales_and_ssh_client_quirks() {
+  lab_log INFO "System default locale (locales-all installed); normalize invalid SSH-forwarded LC_* (e.g. macOS LC_CTYPE=UTF-8)"
+  cat >/etc/default/locale <<'LOC'
+LANG=C.UTF-8
+LOC
+  cat >/etc/profile.d/00-fix-ssh-locale.sh <<'FIX'
+# Run before cloud-init locale-check: macOS often forwards LC_CTYPE=UTF-8.
+case ${LC_ALL-} in (UTF-8|utf-8) export LC_ALL=C.UTF-8 ;; esac
+case ${LC_CTYPE-} in (UTF-8|utf-8) export LC_CTYPE=C.UTF-8 ;; esac
+FIX
+  chmod 644 /etc/profile.d/00-fix-ssh-locale.sh
 }
 
 bastion_xfce_performance_defaults() {
@@ -310,6 +324,7 @@ bastion_student_and_ssh
 track_is_s3 && bastion_s3_extras
 bastion_update_hosts
 bastion_install_desktop_packages
+bastion_locales_and_ssh_client_quirks
 bastion_xfce_performance_defaults
 bastion_desktop_shortcuts
 bastion_console_graphical_target

--- a/cloud-init/bastion.sh
+++ b/cloud-init/bastion.sh
@@ -1,6 +1,6 @@
 # Unified bastion customization; lab_log from prepended _lab_log.sh.
 # Template vars: student_password, lab_track
-# Target: Debian stable + XFCE + xrdp (xorgxrdp).
+# Target: Debian 13 (trixie) + XFCE + xrdp (xorgxrdp).
 
 LAB_TRACK="${lab_track}"
 

--- a/cloud-init/bastion.sh
+++ b/cloud-init/bastion.sh
@@ -82,16 +82,13 @@ bastion_student_and_ssh() {
   useradd -m -s /bin/bash -G sudo student
   echo "student:${student_password}" | chpasswd
 
-  for u in debian ubuntu; do
-    if [ -f "/home/$u/.ssh/authorized_keys" ]; then
-      lab_log INFO "Copying SSH authorized_keys from $u to student"
-      install -d -m 700 -o student -g student /home/student/.ssh
-      cp "/home/$u/.ssh/authorized_keys" /home/student/.ssh/authorized_keys
-      chmod 600 /home/student/.ssh/authorized_keys
-      chown -R student:student /home/student/.ssh
-      break
-    fi
-  done
+  if [ -f /home/debian/.ssh/authorized_keys ]; then
+    lab_log INFO "Copying SSH authorized_keys from debian (cloud default user) to student"
+    install -d -m 700 -o student -g student /home/student/.ssh
+    cp /home/debian/.ssh/authorized_keys /home/student/.ssh/authorized_keys
+    chmod 600 /home/student/.ssh/authorized_keys
+    chown -R student:student /home/student/.ssh
+  fi
 
   lab_log INFO "Allowing password authentication for user student (OpenStack client over SSH)"
   cat >/etc/ssh/sshd_config.d/90-student-auth.conf <<'SSHEOF'

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,6 +4,8 @@ output "bastion_connection_info" {
   description = "Bastion VM connection details (null when the lab_track profile sets deploy_bastion = false)."
   value = local.deploy_bastion ? {
     rdp_address = "${openstack_networking_floatingip_v2.bastion_float[0].address}:3390"
+    vnc_address = "${openstack_networking_floatingip_v2.bastion_float[0].address}:5901"
+    ssh_address = "${openstack_networking_floatingip_v2.bastion_float[0].address}:2228"
     username    = "student"
     password    = nonsensitive(random_password.bastion_student[0].result)
   } : null

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,6 @@ output "bastion_connection_info" {
   description = "Bastion VM connection details (null when the lab_track profile sets deploy_bastion = false)."
   value = local.deploy_bastion ? {
     rdp_address = "${openstack_networking_floatingip_v2.bastion_float[0].address}:3390"
-    vnc_address = "${openstack_networking_floatingip_v2.bastion_float[0].address}:5901"
     ssh_address = "${openstack_networking_floatingip_v2.bastion_float[0].address}:2228"
     username    = "student"
     password    = nonsensitive(random_password.bastion_student[0].result)


### PR DESCRIPTION
## Summary

Replaces the Ubuntu 20.04 + Cinnamon bastion with a **Debian 13 (trixie)** stack focused on **RDP performance** and a working **VGA/web console**: **XFCE**, **xrdp/xorgxrdp**, **LightDM** (started only after cloud-init succeeds), **Firefox ESR**, **Python 3 + pip + venv + pipx**, desktop shortcuts, SSH on **2228**, **locales-all** + profile fix for macOS `LC_CTYPE=UTF-8`, **SPICE/QEMU** agents and **Xorg input drivers** for console input. **TigerVNC** was removed after testing.

## Operator / Terraform

- Default `bastion-image`: `Debian-13` (match Glance name in your cloud).
- `bastion_connection_info`: `rdp_address`, `ssh_address`, `username`, `password` (no VNC).
- `lab_track` default remains `operations`; `ssh_key` default `~/.ssh/id_rsa.pub` (same as `main`).

## Docs

README updated for Debian bastion, ports, security groups, and console troubleshooting.

## Testing

Validated in a lab OpenStack project (RDP, SSH, console GUI, shortcuts); merge when review passes.

Made with [Cursor](https://cursor.com)